### PR TITLE
Adding delete to access control allow methods

### DIFF
--- a/nginx/conf.d-dev/sennet-auth.conf
+++ b/nginx/conf.d-dev/sennet-auth.conf
@@ -38,7 +38,7 @@ server {
             # The directive `add_header` doesn't work when response status code is 401, 403 or 500
             # The `always` parameter is specified so the header field will be added regardless of the response code
             add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             
             # Custom headers and headers various browsers should be OK with but aren't
             add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,Authorization, MAuthorization,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
@@ -53,9 +53,9 @@ server {
         }
 
         # Response to the original requests (HTTP methods are case-sensitive) with CORS enabled
-        if ($request_method ~ (POST|GET|PUT)) {
+        if ($request_method ~ (POST|GET|PUT|DELETE)) {
             add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,Authorization, MAuthorization,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
             add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         }

--- a/nginx/conf.d-prod/sennet-auth.conf
+++ b/nginx/conf.d-prod/sennet-auth.conf
@@ -38,7 +38,7 @@ server {
             # The directive `add_header` doesn't work when response status code is 401, 403 or 500
             # The `always` parameter is specified so the header field will be added regardless of the response code
             add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             
             # Custom headers and headers various browsers should be OK with but aren't
             add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,Authorization, MAuthorization,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
@@ -53,9 +53,9 @@ server {
         }
 
         # Response to the original requests (HTTP methods are case-sensitive) with CORS enabled
-        if ($request_method ~ (POST|GET|PUT)) {
+        if ($request_method ~ (POST|GET|PUT|DELETE)) {
             add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,Authorization, MAuthorization,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range' always;
             add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         }


### PR DESCRIPTION
We use a `DELETE` method for deleting user jobs in the `ingest-api`. Currently this feature does not work from the portal because `DELETE` is not in the `Access-Control-Allow-Methods` header. This PR adds `DELETE` in the nginx configurations.